### PR TITLE
feat(task-7): add authorization headers to axios api call

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -25,6 +25,7 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
 
   const uploadFile = async () => {
     console.log("uploadFile to", url);
+    const authorizationToken = localStorage.getItem("authorization_token");
 
     // Get the presigned URL
     const response = await axios({
@@ -32,6 +33,9 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       url,
       params: {
         name: encodeURIComponent(file?.name || ""),
+      },
+      headers: {
+        Authorization: authorizationToken ? `Basic ${authorizationToken}` : "",
       },
     });
     console.log("File to upload: ", file?.name);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,22 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import axios from "axios";
+
+axios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  function (error) {
+    if (error?.response?.status) {
+      alert(
+        `Status: ${error.response.status}, Message: ${error.response.data?.message}`
+      );
+    }
+
+    return Promise.reject(error?.response ?? error);
+  }
+);
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
### TASK-7:
**Task:** https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/7_authorization/task.md

**CloudFront Frontend URL**: https://d1sdfv0c83t751.cloudfront.net/

- To test it on the client side, set credentials to local storage:
```
localStorage.setItem(
  "authorization_token",
  'bXZlZGF0YXlkaW46VEVTVF9QQVNTV09SRA=='
);
```

### What is done:
- [x]     Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)
- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.